### PR TITLE
Fix permissions for docker-entrypoint.sh

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -51,5 +51,6 @@ RUN sh -c "$(curl -fsSL https://starship.rs/install.sh)" -- --yes
 
 # Initial script
 COPY docker-entrypoint.sh /usr/bin
+RUN chmod +x /usr/bin/docker-entrypoint.sh
 
 ENTRYPOINT ["/usr/bin/docker-entrypoint.sh"]


### PR DESCRIPTION
The original error was:

```
docker: Error response from daemon: OCI runtime create failed: container_linux.go:349: starting container process caused "exec: \"/usr/bin/docker-entrypoint.sh\": permission denied": unknown.
```